### PR TITLE
Added Basic Help commands

### DIFF
--- a/src/main/java/com/tcn/vera/commands/builtin/chatHelpCommand.java
+++ b/src/main/java/com/tcn/vera/commands/builtin/chatHelpCommand.java
@@ -1,0 +1,41 @@
+package com.tcn.vera.commands.builtin;
+
+import com.tcn.vera.commands.templates.ChatCommandTemplate;
+import net.dv8tion.jda.api.EmbedBuilder;
+import net.dv8tion.jda.api.entities.Message;
+import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
+
+import java.util.Set;
+
+public class chatHelpCommand extends ChatCommandTemplate {
+    private final Set<ChatCommandTemplate> commandList;
+    private final String prefix;
+
+    public chatHelpCommand(Set<ChatCommandTemplate> commandList, String prefix) {
+        this.commandName = "help";
+        this.aliases = new String[]{"h", "commands", "cmds"};
+        this.help = "Shows this help message containing all chat commands and their descriptions";
+        this.isOwnerCommand = false;
+
+        this.commandList = commandList;
+        this.prefix = prefix;
+    }
+
+
+    @Override
+    public void executeChatCommand(MessageReceivedEvent event, Message message, String messageContent) {
+        //if there are no chat commands, return
+        if (commandList.isEmpty()) {
+            return;
+        }
+
+        EmbedBuilder embedBuilder = new EmbedBuilder()
+                .setTitle("Chat Command Help:")
+                .setColor(0x00ff00);
+
+        commandList.forEach(command -> embedBuilder.addField(prefix + command.getCommandName(), command.getCommandHelp(), false));
+
+        message.reply("").addEmbeds(embedBuilder.build()).queue();
+
+    }
+}

--- a/src/main/java/com/tcn/vera/commands/builtin/slashHelpCommand.java
+++ b/src/main/java/com/tcn/vera/commands/builtin/slashHelpCommand.java
@@ -1,0 +1,37 @@
+package com.tcn.vera.commands.builtin;
+
+import com.tcn.vera.commands.templates.SlashCommandTemplate;
+import net.dv8tion.jda.api.EmbedBuilder;
+import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
+
+import java.util.Set;
+
+public class slashHelpCommand extends SlashCommandTemplate {
+    private final Set<SlashCommandTemplate> commandList;
+
+    public slashHelpCommand(Set<SlashCommandTemplate> commandList) {
+        this.commandName = "help";
+        this.help = "Shows this help message containing all slash commands and their descriptions";
+
+        this.commandList = commandList;
+
+    }
+    @Override
+    public void executeSlashCommand(SlashCommandInteractionEvent event) {
+        //discord forces us to acknowledge the slash command, so we have to reply even if we don't have any commands
+        if (commandList.isEmpty()) {
+            event.reply("Sorry, this bot does not support any slash commands").queue();
+            return;
+        }
+
+        event.deferReply().queue();
+
+        EmbedBuilder embedBuilder = new EmbedBuilder()
+                .setTitle("Slash Command Help:")
+                .setColor(0x00ff00);
+
+        commandList.forEach(command -> embedBuilder.addField(command.getCommandName(), command.getCommandHelp(), false));
+
+        event.getHook().editOriginalEmbeds(embedBuilder.build()).queue();
+    }
+}

--- a/src/main/java/com/tcn/vera/eventHandlers/CommandHandler.java
+++ b/src/main/java/com/tcn/vera/eventHandlers/CommandHandler.java
@@ -27,6 +27,8 @@
  */
 package com.tcn.vera.eventHandlers;
 
+import com.tcn.vera.commands.builtin.chatHelpCommand;
+import com.tcn.vera.commands.builtin.slashHelpCommand;
 import com.tcn.vera.commands.interactions.*;
 import com.tcn.vera.commands.templates.*;
 import com.tcn.vera.utils.VeraUtils;
@@ -80,7 +82,7 @@ public class CommandHandler extends ListenerAdapter {
     /**
      * To create an instance of this class, please use the {@link CommandHandlerBuilder}.
      */
-    CommandHandler(ArrayList<? extends CommandTemplateBase> commandList, ArrayList<String> botOwner, String prefix, ButtonHandler buttonHandler) {
+    CommandHandler(ArrayList<? extends CommandTemplateBase> commandList, ArrayList<String> botOwner, String prefix, ButtonHandler buttonHandler, boolean enableHelpCommands) {
         logger = LoggerFactory.getLogger("Vera: Command Handler");
         this.botOwner = botOwner;
         this.prefix = prefix;
@@ -131,6 +133,25 @@ public class CommandHandler extends ListenerAdapter {
                 buttonHandler.registerButtonSet(buttonInterface.getButtonClassID(), buttonInterface::executeButton);
             }
         }
+
+        //if help commands are enabled, we need to register them too
+        if(enableHelpCommands) {
+            //register the help commands
+            if(!chatCommandSet.isEmpty() && this.chatCommandSet.stream().map(CommandTemplateBase::getCommandName).noneMatch("help"::equalsIgnoreCase)){
+                this.chatCommandSet.add(new chatHelpCommand(chatCommandSet, prefix));
+            }else{
+                logger.error("A chat command with the name \"help\" has already been registered. The default chat help command will not be registered. " +
+                        "If this was intentional, you can disable the default help command by setting enableHelpCommands to false in the CommandHandlerBuilder.");
+            }
+
+            if(!slashCommandSet.isEmpty() && this.slashCommandSet.stream().map(CommandTemplateBase::getCommandName).noneMatch("help"::equalsIgnoreCase)){
+                this.slashCommandSet.add(new slashHelpCommand(slashCommandSet));
+            }else{
+                logger.error("A slash command with the name \"help\" has already been registered. The default slash help command will not be registered. " +
+                        "If this was intentional, you can disable the default help command by setting enableHelpCommands to false in the CommandHandlerBuilder.");
+            }
+        }
+
         logger.info("Registered " + chatCommandSet.size() + " chat command(s).");
         logger.info("Registered " + slashCommandSet.size() + " slash command(s).");
         logger.info("Registered " + userContextCommandSet.size() + " user context menu command(s).");
@@ -458,4 +479,33 @@ public class CommandHandler extends ListenerAdapter {
             }
         });
     }
+
+    /**
+     * @return a copy of all of the chat command objects
+     */
+    public List<ChatCommandTemplate> getChatCommandSet() {
+        return List.copyOf(chatCommandSet);
+    }
+
+    /**
+     * @return a copy of all of the slash command objects
+     */
+    public List<SlashCommandTemplate> getSlashCommandSet() {
+        return List.copyOf(slashCommandSet);
+    }
+
+    /**
+     * @return a copy of all of the autocomplete command objects
+     */
+    public List<UserContextTemplate> getUserContextSet() {
+        return List.copyOf(userContextCommandSet);
+    }
+
+    /**
+     * @return a copy of all of the autocomplete command objects
+     */
+    public List<MessageContextTemplate> getMessageContextSet() {
+        return List.copyOf(messageContextCommandSet);
+    }
+
 }

--- a/src/main/java/com/tcn/vera/eventHandlers/CommandHandlerBuilder.java
+++ b/src/main/java/com/tcn/vera/eventHandlers/CommandHandlerBuilder.java
@@ -42,9 +42,11 @@ public class CommandHandlerBuilder {
 
     private ButtonHandler buttonHandler = null;
 
+    private boolean enableDefaultHelpCommand = true;
+
     public CommandHandler build() {
         runChecks();
-        return new CommandHandler(commandList, botOwner, prefix, buttonHandler);
+        return new CommandHandler(commandList, botOwner, prefix, buttonHandler, enableDefaultHelpCommand);
     }
 
     private void runChecks() {
@@ -131,6 +133,20 @@ public class CommandHandlerBuilder {
      */
     public CommandHandlerBuilder addButtonHandler(ButtonHandler buttonHandler) {
         this.buttonHandler = buttonHandler;
+        return this;
+    }
+
+    /**
+     * Determines if Vera should automatically generate help commands for slash and chat commands based on the name and
+     * help strings provided in the command class. If enabled, help commands will only be generated if commands exist in
+     * their respective categories. If disabled, no help commands will be generated.
+     * <p>
+     * Default value: true
+     * @param enable Generates help commands if true, does not generate help commands if false.
+     * @return This builder
+     */
+    public CommandHandlerBuilder enableDefaultHelpCommand(boolean enable) {
+        this.enableDefaultHelpCommand = enable;
         return this;
     }
 


### PR DESCRIPTION
Vera will now automatically generate basic help commands for slash and chat commands.

Added the ability to retrieve copies of the command lists contained within the Command Handler class. These are sorted by interaction types: Chat, Slash, User Context, Message Context.